### PR TITLE
feat: add auth endpoints and web forms

### DIFF
--- a/app/backend/migrations/001_auth.sql
+++ b/app/backend/migrations/001_auth.sql
@@ -1,0 +1,24 @@
+-- enable uuid gen if not present
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NULL,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT,
+  role TEXT DEFAULT 'member',
+  status TEXT DEFAULT 'active',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  last_login_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS password_resets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token TEXT UNIQUE NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_resets_expires ON password_resets(expires_at);

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -2,11 +2,13 @@
   "name": "canvassing-backend",
   "version": "1.0.0",
   "private": true,
-  "scripts": {
-    "start": "node index.js"
-  },
+  "scripts": { "start": "node index.js" },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "fastify": "^4.28.1",
-    "pg": "^8.12.0"
+    "fastify-rate-limit": "^5.9.0",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.12.0",
+    "uuid": "^9.0.1"
   }
 }

--- a/app/backend/routes/auth.js
+++ b/app/backend/routes/auth.js
@@ -1,0 +1,99 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const { v4: uuidv4 } = require('uuid');
+
+const ACCESS_TTL_MIN = Number(process.env.ACCESS_TTL_MIN || 15);
+const RESET_TTL_MIN  = Number(process.env.RESET_TTL_MIN  || 60);
+const JWT_SECRET     = process.env.JWT_SECRET || 'dev-secret-change-me';
+
+function signAccess(user) {
+  return jwt.sign(
+    { sub: user.id, email: user.email, role: user.role, tenant_id: user.tenant_id || null },
+    JWT_SECRET,
+    { algorithm: 'HS256', expiresIn: `${ACCESS_TTL_MIN}m` }
+  );
+}
+
+module.exports = function registerAuth(app) {
+  const db = app.db;
+
+  // REGISTER
+  app.post('/v1/auth/register', async (req, reply) => {
+    const { email, password, name } = req.body || {};
+    if (!email || !password) return reply.code(400).send({ error: 'email and password required' });
+    const hash = await bcrypt.hash(password, 12);
+
+    const sql = `
+      INSERT INTO users (id, tenant_id, email, password_hash, name, role, status)
+      VALUES ($1, NULL, $2, $3, $4, 'member', 'active')
+      ON CONFLICT (email) DO NOTHING
+      RETURNING id, email, role, tenant_id
+    `;
+    const id = uuidv4();
+    const res = await db.query(sql, [id, email.toLowerCase().trim(), hash, name || null]);
+    if (res.rowCount === 0) return reply.code(409).send({ error: 'email already registered' });
+    return { ok: true };
+  });
+
+  // LOGIN
+  app.post('/v1/auth/login', async (req, reply) => {
+    const { email, password } = req.body || {};
+    if (!email || !password) return reply.code(400).send({ error: 'email and password required' });
+
+    const q = await db.query('SELECT id, email, password_hash, role, tenant_id FROM users WHERE email=$1', [email.toLowerCase().trim()]);
+    if (q.rowCount === 0) return reply.code(401).send({ error: 'invalid credentials' });
+    const user = q.rows[0];
+
+    const ok = await bcrypt.compare(password, user.password_hash);
+    if (!ok) return reply.code(401).send({ error: 'invalid credentials' });
+
+    const token = signAccess(user);
+    await db.query('UPDATE users SET last_login_at=now() WHERE id=$1', [user.id]);
+    return { access_token: token, user: { id: user.id, email: user.email, role: user.role, tenant_id: user.tenant_id } };
+  });
+
+  // FORGOT (always 200)
+  app.post('/v1/auth/forgot-password', async (req, reply) => {
+    const { email } = req.body || {};
+    const e = (email || '').toLowerCase().trim();
+    const q = await db.query('SELECT id FROM users WHERE email=$1', [e]);
+
+    if (q.rowCount > 0) {
+      const userId = q.rows[0].id;
+      const token = uuidv4().replace(/-/g, '') + uuidv4().replace(/-/g, '');
+      const expires = new Date(Date.now() + RESET_TTL_MIN * 60 * 1000);
+      await db.query(
+        `INSERT INTO password_resets (user_id, token, expires_at) VALUES ($1,$2,$3)
+         ON CONFLICT (token) DO NOTHING`,
+        [userId, token, expires]
+      );
+      // MVP: log the reset URL (replace with email later)
+      app.log.warn(`Password reset link: ${(process.env.APP_BASE_URL || 'http://localhost:3000')}/reset?token=${token}`);
+    }
+    return { ok: true };
+  });
+
+  // RESET
+  app.post('/v1/auth/reset-password', async (req, reply) => {
+    const { token, new_password } = req.body || {};
+    if (!token || !new_password) return reply.code(400).send({ error: 'token and new_password required' });
+
+    const q = await db.query(
+      `SELECT pr.id, pr.user_id, pr.expires_at, pr.used_at
+       FROM password_resets pr
+       WHERE pr.token=$1`,
+      [token]
+    );
+    if (q.rowCount === 0) return reply.code(400).send({ error: 'invalid token' });
+
+    const row = q.rows[0];
+    if (row.used_at) return reply.code(400).send({ error: 'token already used' });
+    if (new Date(row.expires_at).getTime() < Date.now()) return reply.code(400).send({ error: 'token expired' });
+
+    const hash = await bcrypt.hash(new_password, 12);
+    await db.query('UPDATE users SET password_hash=$1 WHERE id=$2', [hash, row.user_id]);
+    await db.query('UPDATE password_resets SET used_at=now() WHERE id=$1', [row.id]);
+
+    return { ok: true };
+  });
+};

--- a/app/web/next-env.d.ts
+++ b/app/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -12,5 +12,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.5.4"
+  },
+  "devDependencies": {
+    "@types/node": "24.2.1",
+    "@types/react": "19.1.9"
   }
 }

--- a/app/web/pages/forgot.tsx
+++ b/app/web/pages/forgot.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+export default function Forgot(){
+  const [email,setEmail]=useState(''); const [msg,setMsg]=useState('');
+  const API=process.env.NEXT_PUBLIC_API_BASE||'http://localhost:8080';
+  async function submit(e:any){ e.preventDefault(); setMsg('');
+    await fetch(API+'/v1/auth/forgot-password',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email})});
+    setMsg('If that email exists, a reset link has been sent.');
+  }
+  return (<main style={{maxWidth:420,margin:'40px auto',padding:20}}>
+    <h1>Forgot password</h1>{msg&&<div>{msg}</div>}
+    <form onSubmit={submit}>
+      <input placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required/><br/>
+      <button type="submit">Send reset link</button>
+    </form>
+    <div style={{marginTop:10}}><a href="/login">Back to login</a></div>
+  </main>);
+}

--- a/app/web/pages/login.tsx
+++ b/app/web/pages/login.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [email, setEmail] = useState(''); const [password, setPassword] = useState('');
+  const [msg, setMsg] = useState('');
+  const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+  async function submit(e:any){
+    e.preventDefault(); setMsg('');
+    const res = await fetch(API + '/v1/auth/login', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if(res.ok){ localStorage.setItem('token', data.access_token); location.href = '/'; }
+    else setMsg(data.error || 'Login failed');
+  }
+
+  return (
+    <main style={{maxWidth:420, margin:'40px auto', padding:20}}>
+      <h1>Login</h1>
+      {msg && <div style={{color:'red'}}>{msg}</div>}
+      <form onSubmit={submit}>
+        <input placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required/><br/>
+        <input placeholder="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)} required/><br/>
+        <button type="submit">Login</button>
+      </form>
+      <div style={{marginTop:10}}>
+        <a href="/register">Create account</a> · <a href="/forgot">Forgot password?</a>
+      </div>
+    </main>
+  );
+}

--- a/app/web/pages/register.tsx
+++ b/app/web/pages/register.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+export default function Register(){
+  const [email,setEmail]=useState(''); const [password,setPassword]=useState(''); const [name,setName]=useState('');
+  const [msg,setMsg]=useState(''); const API=process.env.NEXT_PUBLIC_API_BASE||'http://localhost:8080';
+  async function submit(e:any){ e.preventDefault(); setMsg('');
+    const r=await fetch(API+'/v1/auth/register',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({email,password,name})}); const d=await r.json();
+    if(r.ok){ setMsg('Account created. You can log in.'); } else setMsg(d.error||'Registration failed');
+  }
+  return (<main style={{maxWidth:420,margin:'40px auto',padding:20}}>
+    <h1>Create account</h1>{msg&&<div>{msg}</div>}
+    <form onSubmit={submit}>
+      <input placeholder="Name (optional)" value={name} onChange={e=>setName(e.target.value)}/><br/>
+      <input placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required/><br/>
+      <input placeholder="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)} required/><br/>
+      <button type="submit">Register</button>
+    </form>
+    <div style={{marginTop:10}}><a href="/login">Back to login</a></div>
+  </main>);
+}

--- a/app/web/pages/reset.tsx
+++ b/app/web/pages/reset.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+export default function Reset(){
+  const [token,setToken]=useState(''); const [pwd,setPwd]=useState(''); const [msg,setMsg]=useState('');
+  const API=process.env.NEXT_PUBLIC_API_BASE||'http://localhost:8080';
+
+  useEffect(()=>{ const u=new URL(location.href); setToken(u.searchParams.get('token')||''); },[]);
+  async function submit(e:any){ e.preventDefault(); setMsg('');
+    const r=await fetch(API+'/v1/auth/reset-password',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token,new_password:pwd})});
+    const d=await r.json(); if(r.ok) setMsg('Password updated. You can now log in.'); else setMsg(d.error||'Failed'); 
+  }
+
+  return (<main style={{maxWidth:420,margin:'40px auto',padding:20}}>
+    <h1>Reset password</h1>{msg&&<div>{msg}</div>}
+    <form onSubmit={submit}>
+      <input placeholder="New password" type="password" value={pwd} onChange={e=>setPwd(e.target.value)} required/><br/>
+      <button type="submit">Update password</button>
+    </form>
+    <div style={{marginTop:10}}><a href="/login">Back to login</a></div>
+  </main>);
+}

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement Fastify auth routes for register/login/forgot/reset
- add SQL migration for users and password reset tracking
- add Next.js pages for login, registration, forgot and reset flows

## Testing
- `npm install` (backend)
- `npm test` (backend) *(fails: Missing script: "test")*
- `node index.js` (backend)
- `npm install` (web)
- `npm test` (web) *(fails: Missing script: "test")*
- `npm run build` (web)


------
https://chatgpt.com/codex/tasks/task_e_6896ae104d4083308a77854925f17158